### PR TITLE
Set SSH keys in cloud init

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -17,6 +17,25 @@ provider "registry.terraform.io/e-breuninger/netbox" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/http" {
+  version = "3.4.1"
+  hashes = [
+    "h1:RLJ1zsc2ScUFapTANM91XHyAY7715gP3yPlBOcaBKuk=",
+    "zh:2a79832069a34e88ec997fb8d2c2bdad6f40bfe93a4ae5e6e7f0caf4eea2a9e5",
+    "zh:37d3611857ab207e1565e441a2df9020b1326b7df31e5656165cb6817306494b",
+    "zh:48cc974b12544be18c18bfcb5ea21a4818d03b897e96fb9b4d0d9303883cb3fa",
+    "zh:4b8da2ffe868082830173fdcc8632e2705918e0396c72158d7822650bb1d3bf6",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8148614299a21be04dd11268047e110df3ce9ef585d6240bed2f196839946efa",
+    "zh:a6d583cb70b1355fbc7b1c2cffaa53e4703b04ced9d0ecf78708129ce7072128",
+    "zh:a95f770e8913dd48fde8836cf993fafdbf7da5308a6fbd3d455cb10737742990",
+    "zh:b36784e6602e6ae7ba67560ebcfd055b4448cb0edf9bf35744c2f32ddbd8fa2d",
+    "zh:c23b37fd9e481269fc55735b24c7e8877057c08b42671c796816409d54486a1c",
+    "zh:df07252b27120020d91d7ad11f7ea92832d8df2e81b55a658ac1eb93dc6b8d18",
+    "zh:e44dc5a1fd5995bfd21d385949d539c619e8b37b69875bd92ad4aa18e2435722",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.2.2"
   hashes = [

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -11,4 +11,6 @@ module "supernode" {
   prefix_ipv4_id          = data.netbox_prefix.primary_ipv4.id
   prefix_ipv6_id          = netbox_available_prefix.domain_ipv6.id
   loopback_prefix_ipv6_id = netbox_prefix.loopback_ipv6.id
+
+  vm_ssh_keys = local.ssh_keys
 }

--- a/terraform/modules/supernode/variables.tf
+++ b/terraform/modules/supernode/variables.tf
@@ -53,3 +53,8 @@ variable "vm_resource_pool" {
   description = "Proxmox pool to create VM in"
   default     = "Supernodes2.0"
 }
+
+variable "vm_ssh_keys" {
+  type        = list(string)
+  description = "Public keys to grant access to"
+}

--- a/terraform/modules/supernode/vm.tf
+++ b/terraform/modules/supernode/vm.tf
@@ -41,13 +41,14 @@ resource "proxmox_vm_qemu" "supernode" {
   agent     = 1
   os_type   = "cloud-init"
   ipconfig0 = "ip=dhcp,ip6=${netbox_available_ip_address.management_ipv6.ip_address}"
+  ciuser    = "admin"
+  sshkeys   = join("\n", var.vm_ssh_keys)
 
   define_connection_info = false
 
   lifecycle {
     ignore_changes = [
-      full_clone,
-      define_connection_info
+      define_connection_info,
     ]
   }
 }

--- a/terraform/ssh.tf
+++ b/terraform/ssh.tf
@@ -1,0 +1,12 @@
+data "http" "github_keys" {
+  for_each = toset(var.ssh_github_users)
+  url      = "https://github.com/${each.key}.keys"
+}
+
+locals {
+  ssh_keys = flatten([for name, resp in data.http.github_keys : split("\n", chomp(resp.response_body))])
+}
+
+output "ssh_keys" {
+  value = local.ssh_keys
+}

--- a/terraform/ssh.tf
+++ b/terraform/ssh.tf
@@ -6,7 +6,3 @@ data "http" "github_keys" {
 locals {
   ssh_keys = flatten([for name, resp in data.http.github_keys : split("\n", chomp(resp.response_body))])
 }
-
-output "ssh_keys" {
-  value = local.ssh_keys
-}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -27,3 +27,9 @@ variable "primary_prefix_ipv6" {
   description = "Prefix to issue primary IPv6 addresses from"
   default     = "2001:678:b7c::/48"
 }
+
+variable "ssh_github_users" {
+  type        = list(string)
+  description = "Users to gather SSH public keys from GitHub for"
+  default     = ["mraerino", "nomaster"]
+}


### PR DESCRIPTION
Fetch public SSH keys from GitHub for a list of users and sets them in the VMs via cloud-init