### PR TITLE
Fix disk type to match clone source

### DIFF
--- a/terraform/modules/supernode/vm.tf
+++ b/terraform/modules/supernode/vm.tf
@@ -12,7 +12,7 @@ resource "proxmox_vm_qemu" "supernode" {
   memory  = 1024
 
   disk {
-    type    = "virtio"
+    type    = "scsi"
     storage = var.vm_storage_pool_name
     size    = "4G"
   }
@@ -46,7 +46,6 @@ resource "proxmox_vm_qemu" "supernode" {
 
   lifecycle {
     ignore_changes = [
-      full_clone,
       define_connection_info
     ]
   }


### PR DESCRIPTION
It seems that if this doesn't match the disk type of the template VM we're cloning from that there are two disk entries. That seems bad.